### PR TITLE
Update error.js

### DIFF
--- a/events/error.js
+++ b/events/error.js
@@ -1,4 +1,3 @@
 module.exports = async (client, error) => {
   client.logger.log(`An error event was sent by Discord.js: \n${JSON.stringify(error)}`, "error");
-  message.channel.send(`An error event was sent by Discord.js: \n${JSON.stringify(error)}`, "error");
 };


### PR DESCRIPTION
There's no reason to have the bot send a message to the user when there is an discord.js emitted error. Removed that.
