### PR TITLE
use client.destroy

### DIFF
--- a/commands/shutdown.js
+++ b/commands/shutdown.js
@@ -3,7 +3,7 @@ exports.run = async (client, message, args, level) => {// eslint-disable-line no
   client.commands.forEach( async cmd => {
     await client.unloadCommand(cmd);
   });
-  process.exit(80);
+  client.destory();
 };
 
 exports.conf = {


### PR DESCRIPTION
In order to "shut down" a Discord bot (using Discord.js) you cannot use `process.exit` because that'll just restart the bot, therefore you have to use `client.destroy` 
